### PR TITLE
Return totalItems from usePagination

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,6 +103,7 @@ function usePagination({
         ),
         currentPage,
         pageSize,
+        totalItems,
         ...paginationState,
     };
 }


### PR DESCRIPTION
`totalItems` is passed as a param to `usePagination` hook, but it isn't returned back. seems redundant to have to pass the `totalItems` around explicitly. This way we can simple spread out the pagination props returned from usePagination.