### PR TITLE
Fix README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ const { startIndex, endIndex } = usePagination({ totalItems: data.length, initia
 
 return (
     <ul>
-        {data.slice(startIndex, endIndex).map((item) => (
+        {data.slice(startIndex, endIndex + 1).map((item) => (
             <li>{item}</li>
         ))}
     </ul>
@@ -161,7 +161,7 @@ React.useEffect(() => {
 
 return (
     <ul>
-        {data.slice(startIndex, endIndex).map((item) => (
+        {data.map((item) => (
             <li>{item}</li>
         ))}
     </ul>


### PR DESCRIPTION
Both the client-side and server-side pagination examples seem to have issues with them:

The client-side pagination shows `.slice(startIndex, endIndex)` when the correct version seems to be `.slice(startIndex, endIndex + 1)`.  This caused both the obvious problem of showing one too few items, but also caused the entire list to briefly render when the data has loaded but `endIndex` is still `-1`.  (Since `data.slice(0, -1)` is the whole list)

The server-side pagination shows `endIndex` being used, even though it's not defined.  I think just mapping the whole data array is correct here.